### PR TITLE
fix: add missing hyphen on window name

### DIFF
--- a/src/utils.sh
+++ b/src/utils.sh
@@ -62,6 +62,7 @@ clean_window_name() {
   debug "Window name before cleanup: $1"
   echo "$1" |\
     # Strip ../ prefix from directory
-    sed 's/..\///g'
+    sed 's/..\///g' |\
+    sed 's/ /-/g'
   debug "Window name after cleanup: $1"
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -124,12 +124,12 @@ teardown() {
 }
 
 @test "window name removes ../ prefix correctly" {
-    result=$(clean_window_name "../worktree-name")
+    result=$(clean_window_name "../worktree name")
     assert_equal "$result" "worktree-name"
 }
 
 @test "window name handles multiple ../ correctly" {
-    result=$(clean_window_name "../../worktree-name")
+    result=$(clean_window_name "../../worktree name")
     assert_equal "$result" "worktree-name"
 }
 


### PR DESCRIPTION
Changes:
 - Update's `clean_window_name` function with replacing spaces with hyphens