### PR TITLE
fix: correct test file for target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ endif
 test-main: build
 	@echo "Running main script tests in Docker..."
 ifdef VERBOSE
-	@docker run --rm $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) bats test/main.bats --tap
+	@docker run --rm $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) bats test/git-worktree.bats --tap
 else
-	@docker run --rm $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) bats test/main.bats
+	@docker run --rm $(DOCKER_IMAGE_NAME):$(DOCKER_TAG) bats test/git-worktree.bats
 endif
 
 shell: build


### PR DESCRIPTION
A recent refactor renamed the `main.bats` to `git-worktree.bats`. This carries that change over

Changes:
 - Correct test file name