### PR TITLE
fix: remove chars from branch name

### DIFF
--- a/src/interface/fzf_modules/commit_ops.sh
+++ b/src/interface/fzf_modules/commit_ops.sh
@@ -10,6 +10,6 @@ select_commit_with_fzf() {
       --print-query \
       --header="Enter: Select branch | $show_commit_ref_binding: switch to commit refs" \
       --bind="$show_commit_ref_binding:become(git --no-pager log --no-color --oneline --no-merges --decorate | fzf --print-query  --prompt='Select commit ref: ' | tail -1 | awk '{print \$1}')" |\
-    awk '{print $1}' |\
+    awk '{if (NF > 1) print $2; else print $1}' |\
     tail -1
 }

--- a/test/journeys/create_new_worktree.bats
+++ b/test/journeys/create_new_worktree.bats
@@ -63,3 +63,19 @@ teardown() {
   assert_output --partial "BRANCH=existing-branch"
   refute_output --partial "NEW_BRANCH="  # Should not create new branch
 }
+
+@test "user creates a new worktree from existing branch which is associated to a worktree" {
+  mock_git_capture_worktree_add
+  mock_fzf_create_worktree "my-new-worktree" "branch-with-worktree"
+  mock_tmux_capture_window
+  setup_source_files
+
+  run "$MAIN_SCRIPT"
+
+  assert_success
+  [[ -f /tmp/git_worktree_add.txt ]] || skip "git worktree add was not called"
+
+  run cat /tmp/git_worktree_add.txt
+  assert_output --partial "my-new-worktree"
+  assert_output --partial "NEW_BRANCH=branch-with-worktree"
+}

--- a/test/mocks/fzf_mocks.bash
+++ b/test/mocks/fzf_mocks.bash
@@ -32,11 +32,17 @@ mock_fzf_create_worktree() {
   MOCK_FZF_COMMIT_REF="${3:-}"
   export MOCK_FZF_WT_NAME MOCK_FZF_BRANCH_NAME MOCK_FZF_COMMIT_REF
 
+  # Reset the counter for this test
+  rm -f /tmp/fzf_call_count
+
   fzf() {
     local count_file="/tmp/fzf_call_count"
-    [[ ! -f "$count_file" ]] && echo "0" > "$count_file"
+    local call_count=0
 
-    local call_count=$(cat "$count_file")
+    if [[ -f "$count_file" ]]; then
+      call_count=$(cat "$count_file")
+    fi
+
     call_count=$((call_count + 1))
     echo "$call_count" > "$count_file"
 
@@ -99,6 +105,9 @@ mock_fzf_select_existing_branch() {
   MOCK_FZF_WT_NAME="$1"
   MOCK_FZF_BRANCH_NAME="$2"
   export MOCK_FZF_WT_NAME MOCK_FZF_BRANCH_NAME
+
+  # Reset the counter for this test
+  rm -f /tmp/fzf_call_count
 
   fzf() {
     local count_file="/tmp/fzf_call_count"

--- a/test/mocks/git_mocks.bash
+++ b/test/mocks/git_mocks.bash
@@ -111,6 +111,7 @@ mock_git_capture_worktree_add() {
         ;;
       branch)
         echo "  main"
+        echo "+ branch-with-worktree"
         echo "  feature-branch"
         echo "  existing-branch"
         echo "  remotes/origin/main"


### PR DESCRIPTION
Changes:
 - Remove `+ ` from branch name when passing to the worktree add command

Adds:
 - Test around bug

closes: #41