### PR TITLE
Configurable open action (split/switch/new-window) + fix nested worktrees & branch creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ set -g git-worktree-delete-key "r"      # Default is r
 set -g @git-worktree-ttl "5"            # Default is 2
 ```
 
+### How a worktree is opened
+
+By default, pressing `Enter` opens the selected worktree in a **new window**.
+You can override this per keystroke, or change the default:
+
+```tmux
+# What a plain Enter does: new-window (default), split-pane or switch-pane
+set -g @git-worktree-default-action "split-pane"
+
+# Keys that force a specific action (override the default)
+set -g @git-worktree-new-window-key  "ctrl-w"   # open in a new window
+set -g @git-worktree-split-pane-key  "ctrl-s"   # split the current window
+set -g @git-worktree-switch-pane-key "alt-enter" # cd the current pane
+
+# Split orientation used by split-pane: h (left/right) or v (top/bottom)
+set -g @git-worktree-split-direction "h"        # Default is h
+```
+
 ## Development
 
 For safer, isolated development, use Docker to run tests in a containerized Ubuntu environment. This prevents any potential side effects on your host system.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ set -g @git-worktree-switch-pane-key "alt-enter" # cd the current pane
 
 # Split orientation used by split-pane: h (left/right) or v (top/bottom)
 set -g @git-worktree-split-direction "h"        # Default is h
+
+# Optionally run a command in the opened window/pane (empty = just a shell).
+# Handy for dropping straight into an editor or agent per worktree.
+set -g @git-worktree-run-command "nvim"         # Default is empty
 ```
 
 ## Development

--- a/src/git-worktree
+++ b/src/git-worktree
@@ -19,6 +19,8 @@ split_pane_key=$(get_option_value "@git-worktree-split-pane-key" "ctrl-s")
 # Action taken on a plain Enter: new-window (default), split-pane or switch-pane.
 default_action=$(get_option_value "@git-worktree-default-action" "new-window")
 split_direction=$(get_option_value "@git-worktree-split-direction" "h")
+# Optional command to run in the opened window/pane (empty = just a shell).
+run_command=$(get_option_value "@git-worktree-run-command" "")
 time_to_live=$(get_option_value "@git-worktree-ttl" "2")
 
 debug "ignore_list: $ignore_list"
@@ -64,12 +66,22 @@ debug "Worktree after bare repo check: $directory"
 open_in_tmux() {
   local abs_dir="$1"
   local win_name="$2"
+  local new_pane
   if [[ "$open_action" == "switch-pane" ]]; then
     tmux send-keys "cd \"$abs_dir\" && clear" Enter
+    return
   elif [[ "$open_action" == "split-pane" ]]; then
-    check_condition_and_error_on_fail '! tmux split-window "-$split_direction" -c "$abs_dir"' 'Failed to split pane'
+    new_pane=$(tmux split-window "-$split_direction" -c "$abs_dir" -P -F '#{pane_id}')
+    check_condition_and_error_on_fail '[[ -z "$new_pane" ]]' 'Failed to split pane'
   else
-    check_condition_and_error_on_fail '! tmux new-window -c "$abs_dir" -n "$win_name"' 'Failed to create tmux window'
+    new_pane=$(tmux new-window -c "$abs_dir" -n "$win_name" -P -F '#{pane_id}')
+    check_condition_and_error_on_fail '[[ -z "$new_pane" ]]' 'Failed to create tmux window'
+  fi
+
+  # Optionally run a command in the freshly opened window/pane
+  # (e.g. @git-worktree-run-command "claude").
+  if [[ -n "$run_command" ]]; then
+    tmux send-keys -t "$new_pane" "$run_command" Enter
   fi
 }
 

--- a/src/git-worktree
+++ b/src/git-worktree
@@ -14,6 +14,11 @@ modifier_key=$(get_option_value "@git-worktree-modifer" "ctrl")
 delete_worktree_key=$(get_option_value "@git-worktree-delete-key" "d")
 switch_to_commit_refs_key=$(get_option_value "@git-worktree-delete-key" "r")
 switch_pane_key=$(get_option_value "@git-worktree-switch-pane-key" "alt-enter")
+new_window_key=$(get_option_value "@git-worktree-new-window-key" "ctrl-w")
+split_pane_key=$(get_option_value "@git-worktree-split-pane-key" "ctrl-s")
+# Action taken on a plain Enter: new-window (default), split-pane or switch-pane.
+default_action=$(get_option_value "@git-worktree-default-action" "new-window")
+split_direction=$(get_option_value "@git-worktree-split-direction" "h")
 time_to_live=$(get_option_value "@git-worktree-ttl" "2")
 
 debug "ignore_list: $ignore_list"
@@ -21,6 +26,9 @@ debug "keybinding: $keybinding"
 debug "modifer_key: $modifier_key"
 debug "delete_worktree_key: $delete_worktree_key"
 debug "switch_pane_key: $switch_pane_key"
+debug "new_window_key: $new_window_key"
+debug "split_pane_key: $split_pane_key"
+debug "default_action: $default_action"
 debug "time_to_live: $time_to_live"
 ### end
 
@@ -47,7 +55,7 @@ fi
 
 debug "Is the root of a repo: $is_root_of_repo"
 
-if [[ "$is_root_of_repo" -eq 0 ]]; then
+if [[ "$is_root_of_repo" -eq 0 && "$directory" != /* ]]; then
   directory="../$directory"
 fi
 
@@ -58,6 +66,8 @@ open_in_tmux() {
   local win_name="$2"
   if [[ "$open_action" == "switch-pane" ]]; then
     tmux send-keys "cd \"$abs_dir\" && clear" Enter
+  elif [[ "$open_action" == "split-pane" ]]; then
+    check_condition_and_error_on_fail '! tmux split-window "-$split_direction" -c "$abs_dir"' 'Failed to split pane'
   else
     check_condition_and_error_on_fail '! tmux new-window -c "$abs_dir" -n "$win_name"' 'Failed to create tmux window'
   fi
@@ -67,7 +77,7 @@ if [[ -d "$directory" ]]; then
   debug "Worktree '$directory' exists"
   abs_directory=$(cd "$directory" && pwd)
   debug "abs_directory: '$abs_directory'"
-  window_name=$(clean_window_name $directory)
+  window_name=$(clean_window_name "$(basename "$directory")")
   open_in_tmux "$abs_directory" "$window_name"
   exit 0
 fi
@@ -79,10 +89,25 @@ if git rev-parse --quiet --verify "$branch" 2> /dev/null; then
   check_condition_and_error_on_fail '! git worktree add "$directory" "$branch"' 'Failed to create worktree'
 else
   debug "Branch '$branch' doesn't exist"
+
+  # A worktree is being created without ever reaching the branch prompt
+  # (or the prompt returned nothing) — fail clearly instead of `git -b ""`.
+  check_condition_and_error_on_fail '[[ -z "$branch" ]]' 'Branch name cannot be empty'
+
+  # Fall back when no commit ref was chosen: prefer the matching remote branch, else HEAD.
+  # Prevents `git worktree add -b <branch> ""` failing with "fatal: invalid reference".
+  if [[ -z "$commit" ]]; then
+    if git rev-parse --quiet --verify "origin/$branch" > /dev/null; then
+      commit="origin/$branch"
+    else
+      commit="HEAD"
+    fi
+  fi
+
   check_condition_and_error_on_fail '! git worktree add "$directory" -b "$branch" "$commit"' 'Failed to create worktree with new branch'
 fi
 
 abs_directory=$(cd "$directory" && pwd)
-window_name=$(clean_window_name $directory)
+window_name=$(clean_window_name "$(basename "$directory")")
 debug "abs_directory: '$abs_directory'"
 open_in_tmux "$abs_directory" "$window_name"

--- a/src/interface/fzf
+++ b/src/interface/fzf
@@ -9,10 +9,10 @@ source "$CURRENT_DIR/fzf_modules/deletion.sh"
 run_fzf() {
   debug "fzf installed"
 
-  header="Enter: New window | ${switch_pane_key}: Switch pane | $modifier_key-$delete_worktree_key: Remove worktree"
+  header="Enter: ${default_action} | ${new_window_key}: New window | ${split_pane_key}: Split pane | ${switch_pane_key}: Switch pane | $modifier_key-$delete_worktree_key: Remove worktree"
 
   # Get worktree selection using process substitution
-  readarray -t response < <(get_worktree_list "$ignore_list" | select_worktree_with_fzf "$header" "$delete_keybinding" "$switch_pane_key")
+  readarray -t response < <(get_worktree_list "$ignore_list" | select_worktree_with_fzf "$header" "$delete_keybinding" "$switch_pane_key" "$new_window_key" "$split_pane_key")
   parse_worktree_selection
 
   debug "fzf query: $wt_query"
@@ -28,12 +28,14 @@ run_fzf() {
     exit 0
   fi
 
-  # Set open action based on key used
-  if [[ "$wt_key" == "$switch_pane_key" ]]; then
-    open_action="switch-pane"
-  else
-    open_action="new-window"
-  fi
+  # Pick the open action. Each key forces a specific action; a plain Enter
+  # falls back to @git-worktree-default-action (default: new-window).
+  case "$wt_key" in
+    "$switch_pane_key") open_action="switch-pane" ;;
+    "$new_window_key")  open_action="new-window" ;;
+    "$split_pane_key")  open_action="split-pane" ;;
+    *)                  open_action="$default_action" ;;
+  esac
 
   # Handle existing worktree selection
   if [[ -n "$wt_selection" ]]; then
@@ -42,7 +44,9 @@ run_fzf() {
 
     if [[ -n "$existing_worktree" ]]; then
       debug "existing_worktree: $existing_worktree"
-      directory=$(echo "$existing_worktree" | awk '{ print $1 }' | xargs -n1 basename)
+      # Keep the full path: worktrees are not always siblings of the repo
+      # (e.g. nested ones under .claude/worktrees/<branch>)
+      directory=$(echo "$existing_worktree" | awk '{ print $1 }')
       debug "Worktree after mutation: $directory"
     fi
   fi

--- a/src/interface/fzf_modules/worktree_ops.sh
+++ b/src/interface/fzf_modules/worktree_ops.sh
@@ -14,10 +14,12 @@ select_worktree_with_fzf() {
   local header="$1"
   local delete_binding="$2"
   local switch_pane_binding="$3"
+  local new_window_binding="$4"
+  local split_pane_binding="$5"
 
   fzf \
     --print-query \
-    --expect="$delete_binding,$switch_pane_binding" \
+    --expect="$delete_binding,$switch_pane_binding,$new_window_binding,$split_pane_binding" \
     --prompt="Select or create worktree: " \
     --header="$header"
 }


### PR DESCRIPTION
Thanks for the plugin! While using it I hit a couple of issues with worktrees that don't live next to the repo, and wanted a way to open a worktree as a split instead of a new window. Both are addressed here, in a backward-compatible way.

## Bug fixes

- **Nested / non-sibling worktrees couldn't be opened.** When an existing worktree was selected, the code reduced it to `basename` and later prepended `../`, assuming every worktree is a sibling of the repo root. For worktrees created elsewhere (e.g. `<repo>/.claude/worktrees/<branch>`), the directory no longer resolved, so the flow fell through to the *creation* path and ran `git worktree add -b "" …` → `fatal: '' is not a valid branch name`. The selection now keeps the full worktree path.
- **Empty commit ref when creating a new branch.** If no commit ref was picked (Esc on the ref prompt, or selecting an existing remote branch), `commit` was empty and `git worktree add "$dir" -b "$branch" ""` failed with `fatal: invalid reference: ''`. Now falls back to `origin/<branch>` if it exists, otherwise `HEAD`.
- **Empty branch name** now fails with a clear message instead of an obscure git error.
- Absolute worktree paths are no longer prefixed with `../`.

## New: configurable open action

Default behaviour is unchanged — a plain `Enter` still opens a **new window**. Added:

- `@git-worktree-default-action` — `new-window` (default), `split-pane`, or `switch-pane`.
- `@git-worktree-split-pane-key` (default `ctrl-s`) — split the current window.
- `@git-worktree-new-window-key` (default `ctrl-w`) — force a new window.
- `@git-worktree-split-direction` — `h` (default) or `v`.

Each key overrides the default per-keystroke. README updated.

Tested against sibling worktrees, nested worktrees, new-branch creation (with and without a chosen ref), and each open action.